### PR TITLE
Allows mods/admins to delete posts

### DIFF
--- a/r2/r2/templates/link.html
+++ b/r2/r2/templates/link.html
@@ -108,7 +108,7 @@
 <span class='st_twitter_hcount' displayText='Tweet'></span>
 </div>
       <ul class="action-list">
-          ${self.buttons(comments = False, report=False, delete=False, ban=False)}
+          ${self.buttons(comments = False, report=False, delete=True, ban=False)}
       </ul>
       ## Each link has a hidden status span that is used to indicate voting errors.
       <span id='${"status_"+thing._fullname}' class="error" style="display: none;"></span>


### PR DESCRIPTION
As per issue tog22/eaforum#4

There is now a link (saying delete) in the bottom right of the post, when the mod/admin is on the full-page version of the post (not the summary).
