### PR TITLE
Added ability to link to EA profiles. Profile can be linked to in use…

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -769,7 +769,7 @@ class ProfilePage(Reddit):
 
         if c.user_is_loggedin and self.user._id != c.user._id:
             #User is looking at another user's page, and so can send them a message
-            main_buttons.append(AbsButton('Send Message', 'message/compose/?to=' + self.user.name))
+            main_buttons.append(AbsButton('Send Message', 'message/compose/?to=%s' % (self.user.name)))
 
         return NavMenu(main_buttons, base_path = path, title = _('View'), _id='nav', type='navlist')
 

--- a/r2/r2/templates/articlenavigation.html
+++ b/r2/r2/templates/articlenavigation.html
@@ -58,6 +58,9 @@
   %else:
     <% author_path = unsafe(add_sr("/user/%s/" % websafe(author.name), sr_path = False)) %>
     <a href="${author_path}">${author.name}</a>
+    %if author.pref_url:
+      &nbsp;<a href="${author.pref_url}">(Profile)</a>
+    %endif
   %endif
 </%def>
 

--- a/r2/r2/templates/edit.xml
+++ b/r2/r2/templates/edit.xml
@@ -12,7 +12,13 @@
   <description>
 	<% domain = get_domain(cname = c.cname, subreddit = False) %>
     Edited by &lt;a href="http://${domain}/user/${thing.link_author.name}"&gt;${thing.author.name}&lt;/a&gt;
+    %if thing.author.pref_url:
+      &lt;a href="${thing.author.pref_url}"&gt;(Profile)&lt;/a&gt;
+    %endif
     Original by &lt;a href="http://${domain}/user/${thing.link_author.name}"&gt;${thing.link_author.name}&lt;/a&gt;
+    %if thing.link_author.pref_url:
+      &lt;a href="${thing.link_author.pref_url}"&gt;(Profile)&lt;/a&gt;
+    %endif
     <% entities = {"\n": "&#x0a;"} %>
     &lt;pre&gt;
     ${saxutils.escape("\n".join(thing.diff[2:]), entities)}

--- a/r2/r2/templates/inlinearticle.html
+++ b/r2/r2/templates/inlinearticle.html
@@ -48,7 +48,11 @@
       </a>
     </h3>
     <span>by&#32;<a href="http://${get_domain(cname=True, subreddit=False)}/user/${thing.author.name}">
-      ${thing.author.name}</a>&#32;|&#32;
+      ${thing.author.name}</a>&#32;
+      %if thing.author.pref_url:
+        <a href="${thing.author.pref_url}">(Profile)</a>&#32;
+      %endif
+      |&#32;
       ${thing.score_fmt(thing.score)['label']}v&#32;(${thing.num_comments}c)
     </span>
   </div>

--- a/r2/r2/templates/inlinecomment.html
+++ b/r2/r2/templates/inlinecomment.html
@@ -9,6 +9,10 @@
   <span class="tagline">
     by&#32;<a class="author" href="http://${get_domain(cname=True, subreddit=False)}/user/${thing.author.name}">
     <strong>${thing.author.name}</strong></a>&#32;
+    %if thing.author.pref_url:
+      <a class ="author" href="${thing.author.pref_url}"><strong>(Profile)</strong></a>&#32;
+    ${thing.author.pref_url}
+    %endif
     on&#32;
     <a href="${thing.permalink}" class="article-title">${thing.link.title}</a>
   </span>

--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -44,6 +44,9 @@
       votes_lbl = ungettext("vote", "votes", votes)
     %>
     Submitted by &lt;a href="http://${domain}/user/${thing.author.name}"&gt;${thing.author.name}&lt;/a&gt;
+    %if thing.author.pref_url:
+      &nbsp;&lt;a href="${thing.author.pref_url}"&gt;(Profile)&lt;/a&gt;
+    %endif
     &amp;bull;
     ${votes} ${votes_lbl}
     &amp;bull;

--- a/r2/r2/templates/prefoptions.html
+++ b/r2/r2/templates/prefoptions.html
@@ -128,9 +128,9 @@
           km of me</li>
       </ul>
 
-      <h6>${_("Personal Link")}</h6>
+      <h6>EA Profiles Link</h6>
       <ul>
-        <li><input id="url" name="url" type="text" placeholder="http://yoursite.com/" class="textbox" value="${c.user.pref_url}"/></li>
+        <li><input id="url" name="url" type="url" pattern="(http)?(s?)(:\/\/)?(www.)?effectivealtruismhub\.com\/user\/.*" title="Please enter a link to an EA Profile" placeholder="http://effectivealtruismhub.com/" class="textbox" value="${c.user.pref_url}"/></li>
       </ul>
 
       <button class="btn" type="submit">${_('Save Options')}</button>

--- a/r2/r2/templates/printable.html
+++ b/r2/r2/templates/printable.html
@@ -172,7 +172,10 @@ ${self.RenderPrintable()}
       %if label:
         ${label}
       %endif
-      <a id="author_${thing._fullname}" ${href}>${name}</a>
+      <a id="author_${thing._fullname}" ${href}>${name}</a> 
+      %if author.pref_url:
+        &nbsp;<a id="author_${thing._fullname}" href="${author.pref_url}">(Profile)</a>
+      %endif
     </span>
  %endif
 %endif

--- a/r2/r2/templates/showmeetup.html
+++ b/r2/r2/templates/showmeetup.html
@@ -22,7 +22,11 @@
              if c.user_is_admin: name += " (%d)" % (author.link_karma)
           %>
           posted by
-          <span class="author"><a id="author_${meetup._fullname}" ${href}>${name}</a></span>
+          <span class="author"><a id="author_${meetup._fullname}" ${href}>${name}</a>
+	  %if author.pref_url:
+	    &nbsp;<a id="author_${meetup._fullname}" href=${author.pref_url}>(Profile)</a>
+	  %endif
+	  </span>
           on
         %endif
         <span class="date">${prettytime(meetup._date)}</span>

--- a/r2/r2/templates/topcontributors.html
+++ b/r2/r2/templates/topcontributors.html
@@ -4,6 +4,9 @@
     %for user in thing.things:
       <li class="user">
         <a href="/user/${user.name}">${user.name}</a>
+	%if user.pref_url:
+	  &nbsp;<a href="${user.pref_url}">(Profile)</a>
+	%endif
         <span class='karma'>${user.safe_karma}</span>
       </li>
   </ul>

--- a/r2/r2/templates/topmonthlycontributors.html
+++ b/r2/r2/templates/topmonthlycontributors.html
@@ -4,6 +4,9 @@
     %for user in thing.things:
       <li class="user">
         <a href="/user/${user.name}">${user.name}</a>
+        %if user.pref_url:
+	  &nbsp;<a href="${user.pref_url}">(Profile) Stuff</a>
+	%endif
         <span class='karma'>${user.safe_karma}</span>
       </li>
     %endfor


### PR DESCRIPTION
…r preferences, where it is validated using a regex; profile then shows up beside the link to the user's name wherever possible. This seems to not really work immediately on the top month contributors and on recent comments, possibly due to caching(?). Also, fixed string generation for the message link url to be more efficient.

Peter/other people, this one will probably need a fair amount of testing- I've had trouble testing it myself, as I _think_ the link to the profiles works for meetups, posts, and comments, but not for the sidebar stuff; I think this _may_ be due to previous stuff being cached, but I'm really having trouble telling. (In particular, the sidebar comments list won't register a change to the linked profile until a new coment has been posted, when the cache is updated; the monthly contributors doesn't seem to update at all, so I couldn't really test it.)

c.f. issue tog22/eaforum#1
